### PR TITLE
fix: disable both masterchef and distribution export

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ build: check-version go.sum
 	@-mkdir -p $(BUILD_FOLDER) 2> /dev/null
 	@GOFLAGS=$(GOFLAGS) go build $(build_flags) -o $(BUILD_FOLDER)/post-upgrade-snapshot-generator ./cmd
 
-.PHONY: build
+.PHONY: install build
 
 ## clean: Clean build files. Runs `go clean` internally.
 clean:

--- a/utils/export.go
+++ b/utils/export.go
@@ -20,7 +20,7 @@ func Export(cmdPath, homePath, genesisFilePath string) {
 		// "commitment", // FIXME: causes the balance mismatch error
 		"consensus",
 		"crisis",
-		"distribution",
+		// "distribution", // FIXME: optimize data prior to export as it reached 1.8GB
 		"epochs",
 		"estaking",
 		"evidence",
@@ -32,7 +32,7 @@ func Export(cmdPath, homePath, genesisFilePath string) {
 		"incentive",
 		"interchainaccounts",
 		"leveragelp",
-		"masterchef",
+		// "masterchef", // FIXME: optimize data prior to export as it reached 2.6GB
 		"perpetual",
 		"oracle",
 		"parameter",


### PR DESCRIPTION
disabled both masterchef and distribution module data as it exceeded > 1GB causing the start up process to fail