### PR TITLE
feat: support s3 presigned request

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21
 
 require (
 	github.com/CosmWasm/wasmd v0.41.0
+	github.com/aws/aws-sdk-go v1.44.203
 	github.com/aws/aws-sdk-go-v2 v1.26.1
 	github.com/aws/aws-sdk-go-v2/config v1.27.11
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.11
@@ -33,7 +34,6 @@ require (
 	github.com/DataDog/zstd v1.5.2 // indirect
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
-	github.com/aws/aws-sdk-go v1.44.203 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.2 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.1 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.5 // indirect

--- a/types/presigner.go
+++ b/types/presigner.go
@@ -1,0 +1,65 @@
+package types
+
+import (
+	"context"
+	"log"
+	"time"
+
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go/aws"
+)
+
+// Presigner encapsulates the Amazon Simple Storage Service (Amazon S3) presign actions
+// used in the examples.
+// It contains PresignClient, a client that is used to presign requests to Amazon S3.
+// Presigned requests contain temporary credentials and can be made from any HTTP client.
+type Presigner struct {
+	PresignClient *s3.PresignClient
+}
+
+// GetObject makes a presigned request that can be used to get an object from a bucket.
+// The presigned request is valid for the specified number of seconds.
+func (presigner Presigner) GetObject(
+	bucketName string, objectKey string, lifetimeSecs int64) (*v4.PresignedHTTPRequest, error) {
+	request, err := presigner.PresignClient.PresignGetObject(context.TODO(), &s3.GetObjectInput{
+		Bucket: aws.String(bucketName),
+		Key:    aws.String(objectKey),
+	}, func(opts *s3.PresignOptions) {
+		opts.Expires = time.Duration(lifetimeSecs * int64(time.Second))
+	})
+	if err != nil {
+		log.Printf("Couldn't get a presigned request to get %v:%v. Here's why: %v\n",
+			bucketName, objectKey, err)
+	}
+	return request, err
+}
+
+// PutObject makes a presigned request that can be used to put an object in a bucket.
+// The presigned request is valid for the specified number of seconds.
+func (presigner Presigner) PutObject(
+	bucketName string, objectKey string, lifetimeSecs int64) (*v4.PresignedHTTPRequest, error) {
+	request, err := presigner.PresignClient.PresignPutObject(context.TODO(), &s3.PutObjectInput{
+		Bucket: aws.String(bucketName),
+		Key:    aws.String(objectKey),
+	}, func(opts *s3.PresignOptions) {
+		opts.Expires = time.Duration(lifetimeSecs * int64(time.Second))
+	})
+	if err != nil {
+		log.Printf("Couldn't get a presigned request to put %v:%v. Here's why: %v\n",
+			bucketName, objectKey, err)
+	}
+	return request, err
+}
+
+// DeleteObject makes a presigned request that can be used to delete an object from a bucket.
+func (presigner Presigner) DeleteObject(bucketName string, objectKey string) (*v4.PresignedHTTPRequest, error) {
+	request, err := presigner.PresignClient.PresignDeleteObject(context.TODO(), &s3.DeleteObjectInput{
+		Bucket: aws.String(bucketName),
+		Key:    aws.String(objectKey),
+	})
+	if err != nil {
+		log.Printf("Couldn't get a presigned request to delete object %v. Here's why: %v\n", objectKey, err)
+	}
+	return request, err
+}


### PR DESCRIPTION
the unsigned request using the R2 API has a limit of 5GB per file uploaded, in order to overcome that limit the PR implements pre-signed requests for both upload and delete of snapshot files.