### PR TITLE
fix: update command execution and genesis update logic

### DIFF
--- a/cmd/chaininit/chain-init-cmd.go
+++ b/cmd/chaininit/chain-init-cmd.go
@@ -215,7 +215,7 @@ func ChainInitCmd() *cobra.Command {
 			utils.BackupGenesisInitFile(homePath)
 
 			// update genesis
-			utils.UpdateGenesis(validatorBalance, homePath, genesisFilePath)
+			utils.UpdateGenesis(validatorBalance, oldBinaryPath, homePath, genesisFilePath)
 		},
 	}
 

--- a/utils/get-validator-consensus-address.go
+++ b/utils/get-validator-consensus-address.go
@@ -9,15 +9,15 @@ import (
 	"github.com/elys-network/post-upgrade-snapshot-generator/types"
 )
 
-func GetValidatorConsensusAddress() string {
+func GetValidatorConsensusAddress(cmdPath string) string {
 	// retrieve cons address:
-	cmd := exec.Command("elysd", "tendermint", "show-validator")
+	cmd := exec.Command(cmdPath, "cometbft", "show-validator")
 	validatorPubkey, err := cmd.Output()
 	if err != nil {
 		log.Fatalf(types.ColorRed+"Error getting validator pubkey: %v", err)
 	}
 
-	cmd = exec.Command("elysd", "debug", "pubkey", strings.TrimSpace(string(validatorPubkey)))
+	cmd = exec.Command(cmdPath, "debug", "pubkey", strings.TrimSpace(string(validatorPubkey)))
 	pubkeyOutput, err := cmd.Output()
 	if err != nil {
 		log.Fatalf(types.ColorRed+"Error getting validator address: %v", err)
@@ -32,7 +32,7 @@ func GetValidatorConsensusAddress() string {
 	validatorAddress := matches[1]
 
 	// Get consensus address
-	cmd = exec.Command("elysd", "debug", "addr", validatorAddress)
+	cmd = exec.Command(cmdPath, "debug", "addr", validatorAddress)
 	addrOutput, err := cmd.Output()
 	if err != nil {
 		log.Fatalf(types.ColorRed+"Error getting consensus address: %v", err)

--- a/utils/update-genesis.go
+++ b/utils/update-genesis.go
@@ -11,7 +11,7 @@ import (
 	"github.com/elys-network/post-upgrade-snapshot-generator/types"
 )
 
-func UpdateGenesis(validatorBalance, homePath, genesisFilePath string) {
+func UpdateGenesis(validatorBalance, cmdPath, homePath, genesisFilePath string) {
 	genesis, err := ReadGenesisFile(genesisFilePath)
 	if err != nil {
 		log.Fatalf(types.ColorRed+"Error reading genesis file: %v", err)
@@ -49,16 +49,14 @@ func UpdateGenesis(validatorBalance, homePath, genesisFilePath string) {
 	// add node 1 supply
 	genesis.AppState.Bank.Supply = genesis.AppState.Bank.Supply.
 		Add(sdk.NewCoin("uelys", newValidatorBalance)).
-		Add(sdk.NewCoin("ibc/2180E84E20F5679FCC760D8C165B60F42065DEF7F46A72B447CFF1B7DC6C0A65", newValidatorBalance)).
-		Add(sdk.NewCoin("ibc/E2D2F6ADCC68AA3384B2F5DFACCA437923D137C14E86FB8A10207CF3BED0C8D4", newValidatorBalance)).
-		Add(sdk.NewCoin("ibc/B4314D0E670CB43C88A5DCA09F76E5E812BD831CC2FEC6E434C9E5A9D1F57953", newValidatorBalance))
+		Add(sdk.NewCoin("ibc/F082B65C88E4B6D5EF1DB243CDA1D331D002759E938A0F5CD3FFDC5D53B3E349", newValidatorBalance)).
+		Add(sdk.NewCoin("ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9", newValidatorBalance))
 
 	// add node 2 supply
 	genesis.AppState.Bank.Supply = genesis.AppState.Bank.Supply.
 		Add(sdk.NewCoin("uelys", newValidatorBalance)).
-		Add(sdk.NewCoin("ibc/2180E84E20F5679FCC760D8C165B60F42065DEF7F46A72B447CFF1B7DC6C0A65", newValidatorBalance)).
-		Add(sdk.NewCoin("ibc/E2D2F6ADCC68AA3384B2F5DFACCA437923D137C14E86FB8A10207CF3BED0C8D4", newValidatorBalance)).
-		Add(sdk.NewCoin("ibc/B4314D0E670CB43C88A5DCA09F76E5E812BD831CC2FEC6E434C9E5A9D1F57953", newValidatorBalance))
+		Add(sdk.NewCoin("ibc/F082B65C88E4B6D5EF1DB243CDA1D331D002759E938A0F5CD3FFDC5D53B3E349", newValidatorBalance)).
+		Add(sdk.NewCoin("ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9", newValidatorBalance))
 
 	// Add new validator account and balance
 	genesis.AppState.Auth.Accounts = append(genesis.AppState.Auth.Accounts, genesisInit.AppState.Auth.Accounts...)
@@ -79,7 +77,7 @@ func UpdateGenesis(validatorBalance, homePath, genesisFilePath string) {
 	genesis.AppState.Slashing = genesisInit.AppState.Slashing
 
 	// Add validator signing info to genesis
-	validatorConsAddr := GetValidatorConsensusAddress()
+	validatorConsAddr := GetValidatorConsensusAddress(cmdPath)
 	validatorSigningInfo := types.ValidatorSigningInfo{
 		Address:             validatorConsAddr,
 		StartHeight:         json.Number("0"),


### PR DESCRIPTION
- Modify GetValidatorConsensusAddress to accept cmdPath as a parameter for improved flexibility in command execution.
- Update UpdateGenesis function to include oldBinaryPath in its parameters, enhancing the genesis update process.
- Refactor coin additions in UpdateGenesis to streamline the supply updates for nodes, ensuring consistency in the genesis file structure.